### PR TITLE
Use map::find for environment lookups and throw on missing key

### DIFF
--- a/environment.h
+++ b/environment.h
@@ -6,6 +6,7 @@
 #define ENVIRONMENT_H
 
 #include <map>
+#include <stdexcept>
 
 using std::string;
 using std::map;
@@ -30,7 +31,11 @@ public:
     }
 
     string getVariable(string name) {
-        return env[name];
+        auto it = env.find(name);
+        if (it == env.end()) {
+            throw std::out_of_range("Variable '" + name + "' not found in environment '" + this->name + "'");
+        }
+        return it->second;
     }
 
     const std::map<string,string>::iterator begin() {


### PR DESCRIPTION
## Summary
- Avoid unintended insertion during lookup by switching to `std::map::find` in `Environment::getVariable`
- Throw a descriptive `std::out_of_range` when the variable doesn't exist

## Testing
- `./build/tests`

------
https://chatgpt.com/codex/tasks/task_e_68984c95d8b483248d730df59997e631