### PR TITLE
Refactor validateExpression loop and highlight

### DIFF
--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -203,16 +203,15 @@ std::vector<string> LispInterpreter::listOfValues(std::vector<string> operands, 
 void LispInterpreter::validateExpression(string expression) {
     int parens = 0;
     int i = 0;
-    for (int i = 0; i < expression.length(); i++) {
+    for (; i < static_cast<int>(expression.length()); i++) {
         char c = expression[i];
         if (c == '(') parens++;
         else if (c == ')') parens--;
         if (parens < 0) break;
-        i++;
     }
     if (parens != 0) {
-        string buffer(" ", i);
-        throw std::invalid_argument("Unmatched parens!\n" + expression + "\n" + buffer + "\033[1;31m^\033[0m");
+        std::string highlight = std::string(i, ' ') + "\033[1;31m^\033[0m";
+        throw std::invalid_argument("Unmatched parens!\n" + expression + "\n" + highlight);
     }
 }
 


### PR DESCRIPTION
## Summary
- remove redundant loop counter and internal increment in validateExpression
- build highlight string with std::string and append indicator

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/tests`


------
https://chatgpt.com/codex/tasks/task_e_68984c99a26083249953dfe3b7439c27