### PR TITLE
Use RAII to clean up temporary environments

### DIFF
--- a/interpreter.h
+++ b/interpreter.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <vector>
 #include <string>
+#include <memory>
 #include "environment.h"
 
 using std::string;
@@ -55,7 +56,7 @@ public:
     string applyPrimitiveProcedure(string procedure, std::vector<string> args);
 
     // env management
-    Environment *extendEnvironment(std::vector<string> vars, std::vector<string> vals, Environment *env);
+    std::unique_ptr<Environment> extendEnvironment(std::vector<string> vars, std::vector<string> vals, Environment *env);
 
     // validataion
     static void validateExpression(string expression);


### PR DESCRIPTION
## Summary
- manage temporary interpreter environments with `std::unique_ptr`
- stop adding short-lived frames to the global environment map

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/tests`


------
https://chatgpt.com/codex/tasks/task_e_68984cbb8dbc83248a0aa08a8efce66b