### PR TITLE
Handle empty sequences in evalSequence

### DIFF
--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -238,6 +238,9 @@ bool LispInterpreter::isPrimitiveProcedure(string name) {
 }
 
 string LispInterpreter::evalSequence(std::vector<string> expressions, Environment *env) {
+    if (expressions.empty()) {
+        return "NIL";
+    }
     string ret;
     for (auto const &expression: expressions) {
         ret = eval(expression, env);

--- a/test.cpp
+++ b/test.cpp
@@ -235,6 +235,13 @@ TEST(LispInterpreter, EvalSequenceTest) {
     EXPECT_EQ(intr.evalSequence(vec, &env), "true");
 }
 
+TEST(LispInterpreter, EvalSequenceEmptyTest) {
+    Environment env = Environment("test");
+    LispInterpreter intr = LispInterpreter(&env);
+    std::vector<string> vec{};
+    EXPECT_EQ(intr.evalSequence(vec, &env), "NIL");
+}
+
 TEST(LispInterpreter, EvalAssignmentTest) {
     Environment env = Environment("test");
     LispInterpreter intr = LispInterpreter(&env);


### PR DESCRIPTION
## Summary
- Return "NIL" when evaluating an empty sequence
- Test empty sequence evaluation

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/tests`

------
https://chatgpt.com/codex/tasks/task_e_68984cb8be408324ac319c72d5dc8033