### PR TITLE
Handle empty reductions with informative exception

### DIFF
--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <regex>
 #include <sstream>
+#include <stdexcept>
 
 using std::string;
 using std::map;
@@ -30,7 +31,7 @@ T reduce(const std::vector<T> &data,
     Iterator it = data.cbegin() + leftOffset;
     Iterator end = data.cend() - rightOffset;
     if (it == end) {
-        throw 0;
+        throw std::invalid_argument("empty sequence");
     } else {
         T accumulator = *it;
         ++it;

--- a/repl.cpp
+++ b/repl.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <stdexcept>
 #include "interpreter.h"
 #include "environment.h"
 

--- a/test.cpp
+++ b/test.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <stdexcept>
 #include "interpreter.h"
 #include "environment.h"
 
@@ -67,6 +68,11 @@ TEST(LispInterpreter, IsNumTest) {
     EXPECT_FALSE(LispInterpreter::isFloat(".1"));
     EXPECT_TRUE(LispInterpreter::isFloat("0.1"));
     EXPECT_FALSE(LispInterpreter::isFloat("1..0"));
+}
+
+TEST(LispInterpreter, ArithmeticEmptySequenceThrows) {
+    std::vector<string> empty;
+    EXPECT_THROW(LispInterpreter::arithmetic("+", empty), std::invalid_argument);
 }
 
 TEST(LispInterpreter, IsQuotedStringTest) {


### PR DESCRIPTION
## Summary
- Throw `std::invalid_argument("empty sequence")` when reducing an empty list
- Include `<stdexcept>` in REPL and tests to catch `std::invalid_argument`
- Add unit test for arithmetic on empty sequences

## Testing
- `cmake --build .`
- `./tests`


------
https://chatgpt.com/codex/tasks/task_e_68984c971170832484cef2f162f338a9