### PR TITLE
Use linked environments for variable lookup

### DIFF
--- a/environment.h
+++ b/environment.h
@@ -15,9 +15,8 @@ using std::map;
 
 class Environment {
 public:
-    Environment(string _name) {
-        name = _name;
-    }
+    // Construct an environment optionally linked to an outer environment.
+    Environment(string _name, Environment *_outer = nullptr) : env{}, name(_name), outer(_outer) {}
 
     ~Environment() {
         env.clear();
@@ -34,10 +33,13 @@ public:
 
     string getVariable(Symbol name) {
         auto it = env.find(name);
-        if (it == env.end()) {
-            throw std::out_of_range("Variable '" + symbolToString(name) + "' not found in environment '" + this->name + "'");
+        if (it != env.end()) {
+            return it->second;
         }
-        return it->second;
+        if (outer) {
+            return outer->getVariable(name);
+        }
+        throw std::out_of_range("Variable '" + symbolToString(name) + "' not found in environment '" + this->name + "'");
     }
 
     // string convenience wrappers
@@ -60,6 +62,7 @@ public:
 private:
     map<Symbol, string> env;
     string name;
+    Environment *outer; // link to outer environment (not owned)
 };
 
 #endif //ENVIRONMENT_H

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -155,11 +155,8 @@ string LispInterpreter::eval(const std::vector<string> &expression, Environment 
 
 std::unique_ptr<Environment> LispInterpreter::extendEnvironment(const std::vector<string> &vars, const std::vector<string> &vals, Environment *env) {
     if (vals.size() != vars.size()) throw std::invalid_argument("Vars and vals aren't the same length!");
-    std::unique_ptr<Environment> newEnv(new Environment(env->getName() + std::to_string(frameCount)));
+    std::unique_ptr<Environment> newEnv(new Environment(env->getName() + std::to_string(frameCount), env));
     frameCount++;
-    for (auto it = env->begin(); it != env->end(); ++it) {
-        newEnv->setVariable(it->first, it->second);
-    }
     for (int i = 0; i < vars.size(); i++) {
         newEnv->setVariable(vars[i], vals[i]);
     }


### PR DESCRIPTION
## Summary
- support nested lookups by linking each Environment to an outer scope
- search environment chain when resolving variables
- extend environments by linking to parent instead of copying values

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_689ad35b5a0c83248f32dc85448ec390