### PR TITLE
Enhance REPL with readline history and editing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ add_library(alyssa_lib
 target_include_directories(alyssa_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(repl repl.cpp)
-target_link_libraries(repl PRIVATE alyssa_lib)
+target_link_libraries(repl PRIVATE alyssa_lib readline)
 
 add_executable(tests test.cpp)
 target_link_libraries(tests PRIVATE alyssa_lib GTest::gmock_main GTest::gtest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,15 @@ add_library(alyssa_lib
 )
 target_include_directories(alyssa_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+find_package(Readline)
+
 add_executable(repl repl.cpp)
-target_link_libraries(repl PRIVATE alyssa_lib readline)
+if(Readline_FOUND)
+  target_link_libraries(repl PRIVATE alyssa_lib Readline::Readline)
+  target_compile_definitions(repl PRIVATE HAVE_READLINE)
+else()
+  target_link_libraries(repl PRIVATE alyssa_lib)
+endif()
 
 add_executable(tests test.cpp)
 target_link_libraries(tests PRIVATE alyssa_lib GTest::gmock_main GTest::gtest)

--- a/repl.cpp
+++ b/repl.cpp
@@ -1,7 +1,11 @@
 #include <iostream>
 #include <stdexcept>
-#include <readline/history.h>
 #include <readline/readline.h>
+#if __has_include(<readline/history.h>)
+#include <readline/history.h>
+#else
+extern "C" void add_history(const char*);
+#endif
 #include "interpreter.h"
 #include "environment.h"
 #include "ast.h"

--- a/repl.cpp
+++ b/repl.cpp
@@ -1,5 +1,7 @@
 #include <iostream>
 #include <stdexcept>
+#include <readline/history.h>
+#include <readline/readline.h>
 #include "interpreter.h"
 #include "environment.h"
 #include "ast.h"
@@ -11,17 +13,19 @@ int main() {
     Interpreter intr(&env);
 
     cout << "Alyssa P. Hacker's LISP REPL" << endl;
-    cout << ">> ";
-    string line;
-    while (std::getline(cin, line)) {
-        if (line.empty()) { cout << ">> "; continue; }
+
+    char *raw_line;
+    while ((raw_line = readline(">> ")) != nullptr) {
+        std::string line(raw_line);
+        free(raw_line);
+        if (line.empty()) { continue; }
+        add_history(line.c_str());
         try {
             SExpr result = intr.eval(line);
             cout << "\033[0;32m" << toString(result) << "\033[0m" << endl;
         } catch (const std::exception &e) {
             cout << "\033[1;31m" << e.what() << "\033[0m" << endl;
         }
-        cout << ">> ";
     }
     cout << endl << "LOGOUT" << endl;
 }

--- a/repl.cpp
+++ b/repl.cpp
@@ -1,10 +1,14 @@
+// REPL implementation optionally using GNU Readline
+
 #include <iostream>
 #include <stdexcept>
+#ifdef HAVE_READLINE
 #include <readline/readline.h>
 #if __has_include(<readline/history.h>)
 #include <readline/history.h>
 #else
 extern "C" void add_history(const char*);
+#endif
 #endif
 #include "interpreter.h"
 #include "environment.h"
@@ -18,12 +22,20 @@ int main() {
 
     cout << "Alyssa P. Hacker's LISP REPL" << endl;
 
+#ifdef HAVE_READLINE
     char *raw_line;
     while ((raw_line = readline(">> ")) != nullptr) {
         std::string line(raw_line);
         free(raw_line);
         if (line.empty()) { continue; }
         add_history(line.c_str());
+#else
+    std::string line;
+    while (true) {
+        cout << ">> ";
+        if (!getline(cin, line)) { break; }
+        if (line.empty()) { continue; }
+#endif
         try {
             SExpr result = intr.eval(line);
             cout << "\033[0;32m" << toString(result) << "\033[0m" << endl;


### PR DESCRIPTION
## Summary
- Use GNU Readline for REPL input handling
- Enable command history and arrow-key line editing
- Link REPL against Readline library

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68a018c09d088324be16a8098e29e5a8